### PR TITLE
feat: add account created_at

### DIFF
--- a/src/main/java/spring/springserver/domain/member/entity/Member.kt
+++ b/src/main/java/spring/springserver/domain/member/entity/Member.kt
@@ -9,6 +9,8 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.PrePersist
+import java.time.LocalDateTime
 
 @Entity
 class Member (
@@ -32,6 +34,15 @@ class Member (
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private var id: Long? = null
+
+    private var createdAt: LocalDateTime? = null
+
+    @PrePersist
+    fun prePersistDate() {
+
+        createdAt = LocalDateTime.now()
+    }
+
 
    fun getId(): Long? = id
 }

--- a/src/main/java/spring/springserver/domain/member/entity/Member.kt
+++ b/src/main/java/spring/springserver/domain/member/entity/Member.kt
@@ -43,6 +43,5 @@ class Member (
         createdAt = LocalDateTime.now()
     }
 
-
    fun getId(): Long? = id
 }


### PR DESCRIPTION
## 작업내용
- [x] Member.kt에 사용자 생성 일시인 createdAt을 추가했습니다.

## 관련 이슈
#33 
---
## Member.kt

사용자 생성시 클라이언트에서 시간을 받는게 아닌 데이터베이스에 저장하기 직전에 서버에서 시간을 받아와 저장할 수 있도록 JPA 어노테이션인 PrePersist를 사용했습니다.
```kotlin
@PrePersist
    fun prePersistDate() {

        createdAt = LocalDateTime.now()
    }
```

## 확인사항
- [x] 코드스타일이 컨밴션을 따르는지 확인하셨나요?
- [x] 모든 코드가 정상적으로 동작하는지 확인하셨나요?
