### PR TITLE
fix: add get username with jwt token

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-messaging'
 
     // Phone
-    implementation 'com.github.l98293:phone:1.2.1'
+    implementation 'com.github.L98293:phone:2.1.1'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/spring/springserver/domain/auth/controller/AuthController.kt
+++ b/src/main/java/spring/springserver/domain/auth/controller/AuthController.kt
@@ -2,6 +2,8 @@ package spring.springserver.domain.auth.controller
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -21,14 +23,18 @@ class AuthController(
 ) {
 
     @PostMapping("/signup")
-    fun signUp(@RequestBody signUpRequest: SignUpRequest): BaseResponse<SignUpResponse> {
+    fun signUp(
+        @Valid @RequestBody signUpRequest: SignUpRequest
+    ): BaseResponse<SignUpResponse> {
 
         return BaseResponse.ok(authService.signUp(signUpRequest))
     }
 
     @PostMapping("/signin")
-    fun signIn(@RequestBody signInRequest: SignInRequest,
-                     httpServletResponse: HttpServletResponse): BaseResponse<SignInResponse> {
+    fun signIn(
+        @Valid @RequestBody signInRequest: SignInRequest,
+        httpServletResponse: HttpServletResponse
+    ): BaseResponse<SignInResponse> {
 
         return BaseResponse.ok(authService.signIn(
             signInRequest,
@@ -38,8 +44,10 @@ class AuthController(
     }
 
     @PostMapping("/signout")
-    fun signOut(httpServletRequest: HttpServletRequest,
-                      httpServletResponse: HttpServletResponse) : BaseResponse<SignOutResponse> {
+    fun signOut(
+        httpServletRequest: HttpServletRequest,
+        httpServletResponse: HttpServletResponse
+    ) : BaseResponse<SignOutResponse> {
 
         return BaseResponse.ok(authService.signOut(
             httpServletRequest,

--- a/src/main/java/spring/springserver/domain/auth/controller/TokenController.kt
+++ b/src/main/java/spring/springserver/domain/auth/controller/TokenController.kt
@@ -17,7 +17,9 @@ class TokenController(
 ) {
 
     @GetMapping("/username")
-    fun getCurrentUsername(httpServletRequest: HttpServletRequest): BaseResponse<CurrentUsernameResponse> {
+    fun getCurrentUsername(
+        httpServletRequest: HttpServletRequest
+    ): BaseResponse<CurrentUsernameResponse> {
 
         return BaseResponse.ok(
             CurrentUsernameResponse.of(

--- a/src/main/java/spring/springserver/domain/auth/controller/TokenController.kt
+++ b/src/main/java/spring/springserver/domain/auth/controller/TokenController.kt
@@ -1,0 +1,30 @@
+package spring.springserver.domain.auth.controller
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import spring.springserver.domain.auth.data.response.CurrentUsernameResponse
+import spring.springserver.domain.auth.exception.AuthStatusCode
+import spring.springserver.domain.auth.service.token.TokenService
+import spring.springserver.global.data.BaseResponse
+import spring.springserver.global.exception.exception.ApplicationException
+
+@RestController
+@RequestMapping("/api/token")
+class TokenController(
+    private val tokenService: TokenService
+) {
+
+    @GetMapping("/username")
+    fun getCurrentUsername(httpServletRequest: HttpServletRequest): BaseResponse<CurrentUsernameResponse> {
+
+        return BaseResponse.ok(
+            CurrentUsernameResponse.of(
+                tokenService.getCurrentUsername(
+                    httpServletRequest = httpServletRequest
+                ) ?: throw ApplicationException(AuthStatusCode.INVALID_JWT)
+            )
+        )
+    }
+}

--- a/src/main/java/spring/springserver/domain/auth/data/request/SignUpRequest.kt
+++ b/src/main/java/spring/springserver/domain/auth/data/request/SignUpRequest.kt
@@ -1,5 +1,8 @@
 package spring.springserver.domain.auth.data.request
 
+import com.l98293.phone.Format
+import com.l98293.phone.Phone
+import com.l98293.phone.Region
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
@@ -19,6 +22,10 @@ data class SignUpRequest(
     @field:NotBlank
     val email: String,
 
+    @field:Phone(
+        region = Region.KR,
+        format = Format.LOCAL
+    )
     @field:NotBlank
     val phone: String,
 
@@ -29,8 +36,8 @@ data class SignUpRequest(
     )
     val password: String,
 
-    @field:NotBlank
-    val role: Role,
+    @field:NotNull
+    var role: Role,
 
     @field:NotNull
     var provider: Provider

--- a/src/main/java/spring/springserver/domain/auth/data/response/CurrentUsernameResponse.kt
+++ b/src/main/java/spring/springserver/domain/auth/data/response/CurrentUsernameResponse.kt
@@ -7,7 +7,9 @@ data class CurrentUsernameResponse(
 
     companion object {
 
-        fun of(username: String): CurrentUsernameResponse {
+        fun of(
+            username: String
+        ): CurrentUsernameResponse {
 
             return CurrentUsernameResponse(username)
         }

--- a/src/main/java/spring/springserver/domain/auth/data/response/CurrentUsernameResponse.kt
+++ b/src/main/java/spring/springserver/domain/auth/data/response/CurrentUsernameResponse.kt
@@ -1,0 +1,15 @@
+package spring.springserver.domain.auth.data.response
+
+data class CurrentUsernameResponse(
+
+    val username: String
+) {
+
+    companion object {
+
+        fun of(username: String): CurrentUsernameResponse {
+
+            return CurrentUsernameResponse(username)
+        }
+    }
+}

--- a/src/main/java/spring/springserver/domain/auth/service/token/TokenService.kt
+++ b/src/main/java/spring/springserver/domain/auth/service/token/TokenService.kt
@@ -6,17 +6,27 @@ import spring.springserver.domain.auth.data.request.GenerateTokenRequest
 
 interface TokenService {
 
-    fun generateAccessToken(generateTokenRequest: GenerateTokenRequest,
-                            httpServletResponse: HttpServletResponse?) : String
+    fun generateAccessToken(
+        generateTokenRequest: GenerateTokenRequest,
+        httpServletResponse: HttpServletResponse?
+    ) : String
 
-    fun generateRefreshToken(getTokenRequest: GenerateTokenRequest,
-                             httpServletResponse: HttpServletResponse?) : String
+    fun generateRefreshToken(
+        getTokenRequest: GenerateTokenRequest,
+        httpServletResponse: HttpServletResponse?
+    ) : String
 
-    fun deleteTokens(httpServletRequest: HttpServletRequest,
-                     httpServletResponse: HttpServletResponse)
+    fun deleteTokens(
+        httpServletRequest: HttpServletRequest,
+        httpServletResponse: HttpServletResponse
+    )
 
-    fun extractTokenFromCookie(cookieName: String,
-                               httpServletRequest: HttpServletRequest) : String?
+    fun extractTokenFromCookie(
+        cookieName: String,
+        httpServletRequest: HttpServletRequest
+    ) : String?
 
-    fun getCurrentUsername(httpServletRequest: HttpServletRequest) : String?
+    fun getCurrentUsername(
+        httpServletRequest: HttpServletRequest
+    ) : String?
 }

--- a/src/main/java/spring/springserver/domain/auth/service/token/impl/TokenServiceImpl.kt
+++ b/src/main/java/spring/springserver/domain/auth/service/token/impl/TokenServiceImpl.kt
@@ -130,7 +130,7 @@ class TokenServiceImpl(
                     return cookie.value
                 }
             }
-        } catch (e : Exception) {
+        } catch (_: Exception) {
 
             throw ApplicationException(AuthStatusCode.INVALID_JWT)
         }
@@ -140,8 +140,10 @@ class TokenServiceImpl(
 
     override fun getCurrentUsername(httpServletRequest: HttpServletRequest) : String? {
 
-        val accessToken = extractTokenFromCookie("accessToken",
-                                                 httpServletRequest)
+        val accessToken = extractTokenFromCookie(
+            "accessToken",
+            httpServletRequest
+        )
 
         if(accessToken.isNullOrBlank()) {
 

--- a/src/main/java/spring/springserver/domain/member/entity/Member.kt
+++ b/src/main/java/spring/springserver/domain/member/entity/Member.kt
@@ -1,5 +1,6 @@
 package spring.springserver.domain.member.entity
 
+import com.l98293.phone.Format
 import com.l98293.phone.Phone
 import com.l98293.phone.Region
 import jakarta.persistence.Column
@@ -22,7 +23,10 @@ class Member(
     @Column(unique = true)
     var email: String,
 
-    @field:Phone(region = Region.KR)
+    @field:Phone(
+        region = Region.KR,
+        format = Format.LOCAL
+        )
     var phone: String?,
 
     var password: String?,

--- a/src/main/java/spring/springserver/global/config/SecurityConfig.java
+++ b/src/main/java/spring/springserver/global/config/SecurityConfig.java
@@ -79,6 +79,11 @@ public class SecurityConfig {
 						).hasRole("USER")
 
 						.requestMatchers(
+								HttpMethod.GET,
+								"/api/token/username"
+						).permitAll()
+
+						.requestMatchers(
 								"/chat-test.html",
 								"/ws-stomp/**"
 						).permitAll()

--- a/src/test/kotlin/spring/springserver/domain/payment/service/PaymentBlockchainIntegrationTest.kt
+++ b/src/test/kotlin/spring/springserver/domain/payment/service/PaymentBlockchainIntegrationTest.kt
@@ -1,0 +1,115 @@
+package spring.springserver.domain.payment.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.web.client.RestTemplate
+import spring.springserver.domain.key.entity.MemberKey
+import spring.springserver.domain.key.repository.KeyRepository
+import spring.springserver.domain.member.entity.Member
+import spring.springserver.domain.member.entity.Provider
+import spring.springserver.domain.member.entity.Role
+import spring.springserver.domain.payment.client.TossPaymentsClient
+import spring.springserver.domain.payment.data.request.ConfirmPaymentRequest
+import spring.springserver.domain.payment.data.response.PaymentResponse
+
+@SpringBootTest
+class PaymentBlockchainIntegrationTest {
+
+    @MockBean
+    lateinit var tossPaymentsClient: TossPaymentsClient
+
+    @MockBean
+    lateinit var keyRepository: KeyRepository
+
+    @Autowired
+    lateinit var paymentService: PaymentService
+
+    private val restTemplate = RestTemplate()
+
+    // 테스트용 고정 키쌍 (secp256k1)
+    private val buyerPrivKeyHex = "ab3fc420efc19f4c548be89b5d56533fdc42a290b62d2e9edae19357b08b520b"
+    private val buyerPubKeyHex  = "039d2c2bef52d7560c31328e9cb4049fc16a1df9138d496faab2f885ed54fe05bb"
+    private val testMemberId    = 1L
+    private val testOrderId     = "TEST-ORDER-${System.currentTimeMillis()}"
+
+    @BeforeEach
+    fun setUp() {
+
+        val fakeMember = Member(
+            username = "testuser",
+            name = "테스트유저",
+            email = "test@test.com",
+            phone = null,
+            password = "password",
+            provider = Provider.AUTH,
+            role = Role.USER
+        )
+
+        val fakeMemberKey = MemberKey(
+            member = fakeMember,
+            privateKey = buyerPrivKeyHex,
+            publicKey = buyerPubKeyHex
+        )
+
+        given(keyRepository.findByMemberId(testMemberId)).willReturn(fakeMemberKey)
+
+        given(tossPaymentsClient.confirm(any())).willReturn(
+            PaymentResponse(
+                paymentKey = "test-payment-key-001",
+                orderId = testOrderId,
+                orderName = "테스트 상품",
+                method = "카드",
+                status = "DONE",
+                totalAmount = 10000L,
+                balanceAmount = 10000L,
+                requestedAt = "2024-06-18T18:00:00+09:00",
+                approvedAt = "2024-06-18T18:00:01+09:00",
+                isPartialCancelable = true,
+                card = null,
+                virtualAccount = null,
+                cancels = null,
+                receiptUrl = null,
+                checkoutUrl = null,
+                failure = null,
+                secret = null
+            )
+        )
+    }
+
+    @Test
+    fun `결제 확정 후 체인에 해시가 기록된다`() {
+
+        val request = ConfirmPaymentRequest(
+            paymentKey = "test-payment-key-001",
+            orderId = testOrderId,
+            amount = 10000L
+        )
+
+        val response = paymentService.confirm(
+            request,
+            testMemberId
+        )
+
+        assertThat(response.status).isEqualTo("DONE")
+
+        // 체인에서 결제 기록 조회
+        Thread.sleep(8000)
+
+        val chainResult = restTemplate.getForObject(
+            "http://localhost:1317/cosmos/staking/v1beta1/poa/payment/$testOrderId",
+            Map::class.java
+        )
+
+        println("=== 체인 기록 결과 ===")
+        println(chainResult)
+
+        assertThat(chainResult).isNotNull
+        assertThat(chainResult!!["submission_id"]).isEqualTo(testOrderId)
+    }
+}


### PR DESCRIPTION
## 작업내용
- [ ] JWT 엑세스 토큰을 이용해 사용자명을 조회할 수 있는 엔드포인트를 추가했습니다.
- [ ] 휴대전화 형식을 검증하는 어노테이션 버전을 2.1.1로 업그레이드 함에 따라 엔티티 클래스를 일부 변경했습니다.

```kotlin
// GET /api/token/username 경로로 로그인한 상태에서 요청시 쿠키에서 토큰 값을 조회해 사용자명을 반환합니다.

@RestController
@RequestMapping("/api/token")
class TokenController(
    private val tokenService: TokenService
) {

    @GetMapping("/username")
    fun getCurrentUsername(httpServletRequest: HttpServletRequest): BaseResponse<CurrentUsernameResponse> {

        return BaseResponse.ok(
            CurrentUsernameResponse.of(
                tokenService.getCurrentUsername(
                    httpServletRequest = httpServletRequest
                ) ?: throw ApplicationException(AuthStatusCode.INVALID_JWT)
            )
        )
    }
}
```

```kotlin
// 휴대전화 번호 형식 검증 어노테이션에 format이 추가되었기에 충돌나지 않도록 format을 추가했습니다.

    @field:Phone(
        region = Region.KR,
        format = Format.LOCAL
        )
    var phone: String?,
```


## 관련 이슈
#106 

## 확인사항
- [x] 코드스타일이 컨밴션을 따르는지 확인하셨나요?
- [x] 모든 코드가 정상적으로 동작하는지 확인하셨나요?
